### PR TITLE
reduce API endpoint response sizes for large lists of flights

### DIFF
--- a/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/controller/FlightController.java
+++ b/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/controller/FlightController.java
@@ -1,7 +1,9 @@
 package github.wozniak.flighttrackingservice.controller;
 
 import github.wozniak.flighttrackingservice.dto.FlightDTO;
+import github.wozniak.flighttrackingservice.dto.FlightSummaryDTO;
 import github.wozniak.flighttrackingservice.dto.FlightTimeTableDTO;
+import github.wozniak.flighttrackingservice.dto.TimeTableSummaryDTO;
 import github.wozniak.flighttrackingservice.service.AirportService;
 import github.wozniak.flighttrackingservice.service.FlightService;
 import github.wozniak.flighttrackingservice.service.PlaneService;
@@ -25,14 +27,14 @@ public class FlightController {
         if(!departure.equals("")){
             return ResponseEntity.ok(flightService.findFlightsByAirport(
                     departure, true, airportService)
-                        .stream().map(FlightDTO::new).toList());
+                        .stream().map(FlightSummaryDTO::new).toList());
         }
         if(!destination.equals("")){
             return ResponseEntity.ok(flightService.findFlightsByAirport(
                     destination, false, airportService)
-                        .stream().map(FlightDTO::new).toList());
+                        .stream().map(FlightSummaryDTO::new).toList());
         }
-        return ResponseEntity.ok(flightService.findAllFlights().stream().map(FlightDTO::new).toList());
+        return ResponseEntity.ok(flightService.findAllFlights().stream().map(FlightSummaryDTO::new).toList());
     }
 
     @GetMapping(value = "/identifier/{identifier}")
@@ -60,13 +62,13 @@ public class FlightController {
     @GetMapping(value = "/time_table")
     public ResponseEntity<?> returnFlightsOnDate(@RequestParam("date") String date){
         return ResponseEntity.ok().body(flightService.findFlightsByDate(date).stream()
-                .map(FlightDTO::new).toList());
+                .map(FlightSummaryDTO::new).toList());
     }
 
     @GetMapping(value = "/time_table/range")
     public ResponseEntity<?> returnFlightsOnDate(@RequestParam("start") String start, @RequestParam("end") String end){
         return ResponseEntity.ok().body(flightService.findFlightsByDateRange(start, end).stream()
-                        .map(FlightTimeTableDTO::new).toList());
+                        .map(TimeTableSummaryDTO::new).toList());
     }
 
     /*

--- a/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/dto/AirportSummaryDTO.java
+++ b/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/dto/AirportSummaryDTO.java
@@ -1,0 +1,18 @@
+package github.wozniak.flighttrackingservice.dto;
+
+import github.wozniak.flighttrackingservice.entity.Airport;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class AirportSummaryDTO {
+
+    private String icaoCode;
+    private String name;
+
+    public AirportSummaryDTO(Airport airport){
+        this.icaoCode = airport.getIcaoCode();
+        this.name = airport.getName();
+    }
+}

--- a/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/dto/FlightSummaryDTO.java
+++ b/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/dto/FlightSummaryDTO.java
@@ -1,0 +1,23 @@
+package github.wozniak.flighttrackingservice.dto;
+
+import github.wozniak.flighttrackingservice.entity.Flight;
+import github.wozniak.flighttrackingservice.utils.DateTimeUtils;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class FlightSummaryDTO {
+
+    private long identifier;
+    private RouteSummaryDTO route;
+    private PlaneSummaryDTO plane;
+    private String takeOffDateTime;
+
+    public FlightSummaryDTO(Flight flight){
+        this.identifier = flight.getFlightIdentifier();
+        this.route = new RouteSummaryDTO(flight.getRoute());
+        this.plane = new PlaneSummaryDTO(flight.getPlane());
+        this.takeOffDateTime = DateTimeUtils.format(flight.getTakeOffDateTime());
+    }
+}

--- a/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/dto/PlaneSummaryDTO.java
+++ b/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/dto/PlaneSummaryDTO.java
@@ -1,0 +1,18 @@
+package github.wozniak.flighttrackingservice.dto;
+
+import github.wozniak.flighttrackingservice.entity.Plane;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class PlaneSummaryDTO {
+
+    private String callSign;
+    private String model;
+
+    public PlaneSummaryDTO(Plane plane){
+        this.callSign = plane.getCallSign();
+        this.model = plane.getModel();
+    }
+}

--- a/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/dto/RouteSummaryDTO.java
+++ b/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/dto/RouteSummaryDTO.java
@@ -1,0 +1,23 @@
+package github.wozniak.flighttrackingservice.dto;
+
+import github.wozniak.flighttrackingservice.entity.Route;
+import github.wozniak.flighttrackingservice.utils.DateTimeUtils;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class RouteSummaryDTO {
+
+    private AirportSummaryDTO departure;
+    private AirportSummaryDTO destination;
+    private String flightTime;
+    private double distanceMiles;
+
+    public RouteSummaryDTO(Route route){
+        this.departure = new AirportSummaryDTO(route.getDepartureAirport());
+        this.destination = new AirportSummaryDTO(route.getDestinationAirport());
+        this.flightTime = DateTimeUtils.hoursToHHMM(route.getFlightDurationHours());
+        this.distanceMiles = route.getFlightDistanceMiles();
+    }
+}

--- a/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/dto/TimeTableSummaryDTO.java
+++ b/backend/flight-tracking-service/src/main/java/github/wozniak/flighttrackingservice/dto/TimeTableSummaryDTO.java
@@ -1,0 +1,23 @@
+package github.wozniak.flighttrackingservice.dto;
+
+import github.wozniak.flighttrackingservice.model.FlightTimeTable;
+import github.wozniak.flighttrackingservice.utils.DateTimeUtils;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class TimeTableSummaryDTO {
+    private String date;
+    private int flightCount;
+    private List<FlightSummaryDTO> flights;
+
+    public TimeTableSummaryDTO(FlightTimeTable timeTable){
+        this.date = DateTimeUtils.format(timeTable.getDate());
+        this.flights = timeTable.getFlightsToday().stream().map(FlightSummaryDTO::new).toList();
+        this.flightCount = flights.size();
+    }
+}


### PR DESCRIPTION
Certain endpoints, such as returnAllFlights(), or returnFlightsOnDate() will now return a summarized list of flights, removing unnecessary info such as detailed airport info, plane info etc. These endpoints will largely be used to display as a table to the user, therefore this info is only important when the user wants to look at flights individually